### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ nnoremap g# :<C-u>ListaCursorWord<CR>
 If you prefer to use `<C-n>/<C-p>` to select candidate, use
 
 ```vim
-let g:lista#custom_mapping = [
+let g:lista#custom_mappings = [
       \ ['<C-f>', '<Left>'],
       \ ['<C-b>', '<Right>'],
       \ ['<C-a>', '<Home>'],


### PR DESCRIPTION
Thank you for your nice plugin!
I found an incorrect variable name `g:lista#custom_mapping` in an example of key map settings.
It should be `g:lista#custom_mappings`.